### PR TITLE
feat(config): add TypeScript support, close #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ generateConfig({
 });
 ```
 
+### TypeScript
+
+```js
+// enable TypeScript support
+generateConfig({
+  typescript: true
+});
+
+// enable and configure TypeScript support
+generateConfig({
+  typescript: {
+    vueComponents: true, // allow to lint .vue files, enabled by default if Vue support is enabled 
+  }
+});
+```
+
 ---
 
 ## How to contribute

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "LICENSE"
   ],
   "dependencies": {
+    "@typescript-eslint/eslint-plugin": "^4.5.0",
+    "@typescript-eslint/parser": "^4.5.0",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-config-prettier": "^6.13.0",
     "eslint-import-resolver-node": "^0.3.4",

--- a/src/config-generator.test.ts
+++ b/src/config-generator.test.ts
@@ -10,6 +10,11 @@ describe('config-generator', function () {
         es2021: true,
       },
       parser: '@babel/eslint-parser',
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        }
+      },
       extends: [
         require.resolve('eslint-config-airbnb-base'),
         require.resolve('eslint-config-prettier'),
@@ -48,6 +53,11 @@ describe('config-generator', function () {
           es2021: true,
         },
         parser: 'vue-eslint-parser',
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          }
+        },
         extends: [
           require.resolve('eslint-plugin-vue/lib/configs/recommended'),
           require.resolve('eslint-config-airbnb-base'),
@@ -95,6 +105,11 @@ describe('config-generator', function () {
           es2021: true,
         },
         parser: 'vue-eslint-parser',
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          }
+        },
         extends: [
           require.resolve('eslint-plugin-vue/lib/configs/vue3-recommended'),
           require.resolve('eslint-config-airbnb-base'),
@@ -142,6 +157,11 @@ describe('config-generator', function () {
           es2021: true,
         },
         parser: 'vue-eslint-parser',
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          }
+        },
         extends: [
           require.resolve('eslint-plugin-vue/lib/configs/essential'),
           require.resolve('eslint-config-airbnb-base'),

--- a/src/config-generator.test.ts
+++ b/src/config-generator.test.ts
@@ -197,4 +197,242 @@ describe('config-generator', function () {
       expect(generateConfig(userOptions)).toEqual(expectedConfig);
     });
   });
+
+  describe('TypeScript', function () {
+    test('Basic support', function () {
+      const userOptions: UserOptions = {
+        typescript: true
+      };
+      const expectedConfig: ESLintConfig = {
+        env: {
+          browser: true,
+          es2021: true,
+        },
+        parser: '@typescript-eslint/parser',
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          }
+        },
+        extends: [
+          require.resolve('eslint-config-airbnb-base'),
+          require.resolve('@typescript-eslint/eslint-plugin/dist/configs/eslint-recommended'),
+          require.resolve('@typescript-eslint/eslint-plugin/dist/configs/recommended'),
+          require.resolve('eslint-config-prettier'),
+          require.resolve('eslint-config-prettier/@typescript-eslint'),
+        ],
+        plugins: ['prettier'],
+        settings: {
+          'import/resolver': {
+            [require.resolve('eslint-import-resolver-node')]: {},
+            [require.resolve('eslint-import-resolver-webpack')]: {}
+          },
+          'import/extensions': ['.js', '.jsx', '.mjs', '.ts', '.tsx'],
+        },
+        rules: {
+          'semi': ['error', 'always'],
+          'func-names': 'off',
+          'no-param-reassign': ['error', { props: true, ignorePropertyModificationsFor: ['state', 'acc', 'e'] }],
+          // Import plugin
+          'import/prefer-default-export': 'off',
+          'import/extensions': ['error', 'always', { js: 'never', jsx: 'never', mjs: 'never', ts: 'never', tsx: 'never' }],
+          // TypeScript
+          '@typescript-eslint/naming-convention': [
+            'error',
+            { selector: 'default', format: ['camelCase'], leadingUnderscore: 'allow', trailingUnderscore: 'allow' },
+            { selector: 'variable', format: ['camelCase', 'UPPER_CASE', 'PascalCase'], leadingUnderscore: 'allow', trailingUnderscore: 'allow' },
+            { selector: 'typeLike', format: ['PascalCase'] },
+            { selector: 'property', format: ['camelCase', 'snake_case', 'PascalCase'] }
+          ],
+          // Prettier
+          'prettier/prettier': 'error'
+        },
+        overrides: [
+          {
+            files: ['*.js', '*.jsx', '*.vue'],
+            rules: {
+              '@typescript-eslint/explicit-function-return-type': 'off',
+              '@typescript-eslint/explicit-module-boundary-types': 'off',
+            }
+          },
+          {
+            files: ['*.ts', '*.tsx'],
+            rules: {
+              // The core 'no-unused-vars' rules (in the eslint:recommeded ruleset)
+              // does not work with type definitions
+              'no-unused-vars': 'off',
+              'camelcase': 'off'
+            },
+          }
+        ]
+      };
+
+      expect(generateConfig(userOptions)).toEqual(expectedConfig);
+    });
+
+    test('With Vue support, and automatically enabled .vue files support', function () {
+      const userOptions: UserOptions = {
+        typescript: true,
+        vue: true,
+      };
+      const expectedConfig: ESLintConfig = {
+        env: {
+          browser: true,
+          es2021: true,
+        },
+        parser: 'vue-eslint-parser',
+        parserOptions: {
+          parser: '@typescript-eslint/parser',
+          ecmaFeatures: {
+            jsx: true,
+          },
+          extraFileExtensions: ['.vue']
+        },
+        extends: [
+          require.resolve('eslint-plugin-vue/lib/configs/recommended'),
+          require.resolve('eslint-config-airbnb-base'),
+          require.resolve('@typescript-eslint/eslint-plugin/dist/configs/eslint-recommended'),
+          require.resolve('@typescript-eslint/eslint-plugin/dist/configs/recommended'),
+          require.resolve('eslint-config-prettier'),
+          require.resolve('eslint-config-prettier/vue'),
+          require.resolve('eslint-config-prettier/@typescript-eslint'),
+        ],
+        plugins: ['prettier'],
+        settings: {
+          'import/resolver': {
+            [require.resolve('eslint-import-resolver-node')]: {},
+            [require.resolve('eslint-import-resolver-webpack')]: {}
+          },
+          'import/extensions': ['.js', '.jsx', '.mjs', '.ts', '.tsx'],
+        },
+        rules: {
+          'semi': ['error', 'always'],
+          'func-names': 'off',
+          'no-param-reassign': ['error', { props: true, ignorePropertyModificationsFor: ['state', 'acc', 'e'] }],
+          // Import plugin
+          'import/prefer-default-export': 'off',
+          'import/extensions': ['error', 'always', { js: 'never', jsx: 'never', mjs: 'never', ts: 'never', tsx: 'never' }],
+          // TypeScript
+          '@typescript-eslint/naming-convention': [
+            'error',
+            { selector: 'default', format: ['camelCase'], leadingUnderscore: 'allow', trailingUnderscore: 'allow' },
+            { selector: 'variable', format: ['camelCase', 'UPPER_CASE', 'PascalCase'], leadingUnderscore: 'allow', trailingUnderscore: 'allow' },
+            { selector: 'typeLike', format: ['PascalCase'] },
+            { selector: 'property', format: ['camelCase', 'snake_case', 'PascalCase'] }
+          ],
+          // Vue
+          'vue/component-name-in-template-casing': [`error`, `PascalCase`, {
+            'registeredComponentsOnly': false,
+            'ignores': [],
+          }],
+          'vue/html-self-closing': ['error', { html: { normal: 'never', void: 'always' } }],
+          // Prettier
+          'prettier/prettier': 'error'
+        },
+        overrides: [
+          {
+            files: ['*.js', '*.jsx'/*, '*.vue' */],
+            rules: {
+              '@typescript-eslint/explicit-function-return-type': 'off',
+              '@typescript-eslint/explicit-module-boundary-types': 'off',
+            }
+          },
+          {
+            files: ['*.ts', '*.tsx'],
+            rules: {
+              // The core 'no-unused-vars' rules (in the eslint:recommeded ruleset)
+              // does not work with type definitions
+              'no-unused-vars': 'off',
+              'camelcase': 'off'
+            },
+          }
+        ]
+      };
+
+      expect(generateConfig(userOptions)).toEqual(expectedConfig);
+    });
+
+    test('With Vue support, and disabled .vue files support', function () {
+      const userOptions: UserOptions = {
+        typescript: {
+          vueComponents: false,
+        },
+        vue: true,
+      };
+      const expectedConfig: ESLintConfig = {
+        env: {
+          browser: true,
+          es2021: true,
+        },
+        parser: 'vue-eslint-parser',
+        parserOptions: {
+          parser: '@typescript-eslint/parser',
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+        extends: [
+          require.resolve('eslint-plugin-vue/lib/configs/recommended'),
+          require.resolve('eslint-config-airbnb-base'),
+          require.resolve('@typescript-eslint/eslint-plugin/dist/configs/eslint-recommended'),
+          require.resolve('@typescript-eslint/eslint-plugin/dist/configs/recommended'),
+          require.resolve('eslint-config-prettier'),
+          require.resolve('eslint-config-prettier/vue'),
+          require.resolve('eslint-config-prettier/@typescript-eslint'),
+        ],
+        plugins: ['prettier'],
+        settings: {
+          'import/resolver': {
+            [require.resolve('eslint-import-resolver-node')]: {},
+            [require.resolve('eslint-import-resolver-webpack')]: {}
+          },
+          'import/extensions': ['.js', '.jsx', '.mjs', '.ts', '.tsx'],
+        },
+        rules: {
+          'semi': ['error', 'always'],
+          'func-names': 'off',
+          'no-param-reassign': ['error', { props: true, ignorePropertyModificationsFor: ['state', 'acc', 'e'] }],
+          // Import plugin
+          'import/prefer-default-export': 'off',
+          'import/extensions': ['error', 'always', { js: 'never', jsx: 'never', mjs: 'never', ts: 'never', tsx: 'never' }],
+          // TypeScript
+          '@typescript-eslint/naming-convention': [
+            'error',
+            { selector: 'default', format: ['camelCase'], leadingUnderscore: 'allow', trailingUnderscore: 'allow' },
+            { selector: 'variable', format: ['camelCase', 'UPPER_CASE', 'PascalCase'], leadingUnderscore: 'allow', trailingUnderscore: 'allow' },
+            { selector: 'typeLike', format: ['PascalCase'] },
+            { selector: 'property', format: ['camelCase', 'snake_case', 'PascalCase'] }
+          ],
+          // Vue
+          'vue/component-name-in-template-casing': [`error`, `PascalCase`, {
+            'registeredComponentsOnly': false,
+            'ignores': [],
+          }],
+          'vue/html-self-closing': ['error', { html: { normal: 'never', void: 'always' } }],
+          // Prettier
+          'prettier/prettier': 'error'
+        },
+        overrides: [
+          {
+            files: ['*.js', '*.jsx', '*.vue'],
+            rules: {
+              '@typescript-eslint/explicit-function-return-type': 'off',
+              '@typescript-eslint/explicit-module-boundary-types': 'off',
+            }
+          },
+          {
+            files: ['*.ts', '*.tsx'],
+            rules: {
+              // The core 'no-unused-vars' rules (in the eslint:recommeded ruleset)
+              // does not work with type definitions
+              'no-unused-vars': 'off',
+              'camelcase': 'off'
+            },
+          }
+        ]
+      };
+
+      expect(generateConfig(userOptions)).toEqual(expectedConfig);
+    });
+  });
 });

--- a/src/config-generator.ts
+++ b/src/config-generator.ts
@@ -21,6 +21,11 @@ function getBaseConfig(options: Options): ESLintConfig {
       es2021: true,
     },
     parser: '@babel/eslint-parser',
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      }
+    },
     extends: [
       require.resolve('eslint-config-airbnb-base'),
     ],

--- a/src/config-generator.ts
+++ b/src/config-generator.ts
@@ -1,15 +1,18 @@
+import { Linter } from 'eslint';
 import { normalizeUserOptions, Options, UserOptions } from './options';
 
-export type ESLintConfig = import('eslint').Linter.Config & {
-  extends?: string[]
+export type ESLintConfig = Linter.Config & {
+  extends?: string[],
+  parserOptions: Linter.ParserOptions;
 };
 
 export function generateConfig(userOptions: UserOptions = {}): ESLintConfig {
   const options = normalizeUserOptions(userOptions);
   const config = getBaseConfig(options);
 
-  applyPrettierConfig(config, options);
   applyVueConfig(config, options);
+  applyTypeScriptConfig(config, options);
+  applyPrettierConfig(config, options);
 
   return config;
 }
@@ -62,6 +65,9 @@ function applyPrettierConfig(config: ESLintConfig, options: Options): void {
   if (options.vue) {
     config.extends.push(require.resolve('eslint-config-prettier/vue'));
   }
+  if (options.typescript) {
+    config.extends.push(require.resolve('eslint-config-prettier/@typescript-eslint'));
+  }
   config.plugins = (config.plugins || []).concat('prettier');
   config.rules = {
     ...config.rules || {},
@@ -86,4 +92,53 @@ function applyVueConfig(config: ESLintConfig, options: Options): void {
     }],
     'vue/html-self-closing': ['error', { html: { normal: 'never', void: 'always' } }],
   };
+}
+
+function applyTypeScriptConfig(config: ESLintConfig, options: Options): void {
+  if (options.typescript === false) {
+    return;
+  }
+
+  config.extends?.push(require.resolve('@typescript-eslint/eslint-plugin/dist/configs/eslint-recommended'));
+  config.extends?.push(require.resolve('@typescript-eslint/eslint-plugin/dist/configs/recommended'));
+
+  if (options.vue) {
+    config.parserOptions.parser = '@typescript-eslint/parser';
+  } else {
+    config.parser = '@typescript-eslint/parser';
+  }
+
+  if (options.typescript.vueComponents) {
+    config.parserOptions.extraFileExtensions = ['.vue'];
+  }
+
+  config.rules = {
+    ...config.rules,
+    '@typescript-eslint/naming-convention': [
+      'error',
+      { selector: 'default', format: ['camelCase'], leadingUnderscore: 'allow', trailingUnderscore: 'allow' },
+      { selector: 'variable', format: ['camelCase', 'UPPER_CASE', 'PascalCase'], leadingUnderscore: 'allow', trailingUnderscore: 'allow' },
+      { selector: 'typeLike', format: ['PascalCase'] },
+      { selector: 'property', format: ['camelCase', 'snake_case', 'PascalCase'] }
+    ]
+  };
+
+  config.overrides = (config.overrides || []).concat(
+    {
+      files: ['*.js', '*.jsx'].concat(options.typescript.vueComponents ? [] : ['*.vue']),
+      rules: {
+        '@typescript-eslint/explicit-function-return-type': 'off',
+        '@typescript-eslint/explicit-module-boundary-types': 'off',
+      }
+    },
+    {
+      files: ['*.ts', '*.tsx'],
+      rules: {
+        // The core 'no-unused-vars' rules (in the eslint:recommeded ruleset)
+        // does not work with type definitions
+        'no-unused-vars': 'off',
+        'camelcase': 'off'
+      },
+    },
+  );
 }

--- a/src/options.test.ts
+++ b/src/options.test.ts
@@ -7,6 +7,7 @@ describe('options', function () {
       const expectedOptions: Options = {
         knownExtensions: ['.js', '.jsx', '.mjs', '.ts', '.tsx'],
         vue: false,
+        typescript: false,
       };
 
       expect(normalizeUserOptions(userOptions)).toEqual(expectedOptions);
@@ -19,6 +20,7 @@ describe('options', function () {
       const expectedOptions: Options = {
         knownExtensions: ['.js', '.jsx', '.css'],
         vue: false,
+        typescript: false,
       };
 
       expect(normalizeUserOptions(userOptions)).toEqual(expectedOptions);
@@ -34,7 +36,8 @@ describe('options', function () {
           vue: {
             version: 2,
             config: 'recommended'
-          }
+          },
+          typescript: false,
         };
 
         expect(normalizeUserOptions(userOptions)).toEqual(expectedOptions);
@@ -51,7 +54,8 @@ describe('options', function () {
           vue: {
             version: 3,
             config: 'recommended'
-          }
+          },
+          typescript: false,
         };
 
         expect(normalizeUserOptions(userOptions)).toEqual(expectedOptions);
@@ -68,6 +72,64 @@ describe('options', function () {
           vue: {
             version: 2,
             config: 'essential'
+          },
+          typescript: false,
+        };
+
+        expect(normalizeUserOptions(userOptions)).toEqual(expectedOptions);
+      });
+    });
+
+    describe('with TypeScript support', () => {
+      test('boolean', function () {
+        const userOptions: UserOptions = {
+          typescript: true
+        };
+        const expectedOptions: Options = {
+          knownExtensions: ['.js', '.jsx', '.mjs', '.ts', '.tsx'],
+          vue: false,
+          typescript: {
+            vueComponents: false,
+          }
+        };
+
+        expect(normalizeUserOptions(userOptions)).toEqual(expectedOptions);
+      });
+
+      test('with Vue (auto)', function () {
+        const userOptions: UserOptions = {
+          vue: true,
+          typescript: true
+        };
+        const expectedOptions: Options = {
+          knownExtensions: ['.js', '.jsx', '.mjs', '.ts', '.tsx'],
+          vue: {
+            version: 2,
+            config: 'recommended',
+          },
+          typescript: {
+            vueComponents: true,
+          }
+        };
+
+        expect(normalizeUserOptions(userOptions)).toEqual(expectedOptions);
+      });
+
+      test('without Vue (disabled)', function () {
+        const userOptions: UserOptions = {
+          vue: true,
+          typescript: {
+            vueComponents: false
+          }
+        };
+        const expectedOptions: Options = {
+          knownExtensions: ['.js', '.jsx', '.mjs', '.ts', '.tsx'],
+          vue: {
+            version: 2,
+            config: 'recommended',
+          },
+          typescript: {
+            vueComponents: false,
           }
         };
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,6 +3,9 @@ export interface UserOptions {
   vue?: true | {
     version?: 2 | 3,
     config?: 'essential' | 'recommended' | 'strongly-recommended',
+  },
+  typescript?: true | {
+    vueComponents?: boolean,
   }
 }
 
@@ -11,15 +14,24 @@ export interface Options {
   vue: false | {
     version: 2 | 3,
     config: 'essential' | 'recommended' | 'strongly-recommended',
+  },
+  typescript: false | {
+    vueComponents: boolean,
   }
 }
 
 export function normalizeUserOptions(userOptions: UserOptions = {}): Options {
+  const vueEnabled = userOptions.vue === true || typeof userOptions.vue === 'object';
   const options: Options = {
     knownExtensions: userOptions.knownExtensions || ['.js', '.jsx', '.mjs', '.ts', '.tsx'],
     vue: typeof userOptions.vue === 'undefined' ? false : {
       version: (userOptions.vue === true || typeof userOptions.vue.version === 'undefined') ? 2 : userOptions.vue.version,
       config: (userOptions.vue === true || typeof userOptions.vue.config === 'undefined') ? 'recommended' : userOptions.vue.config,
+    },
+    typescript: typeof userOptions.typescript === 'undefined' ? false : {
+      vueComponents: (userOptions.typescript === true || typeof userOptions.typescript.vueComponents === 'undefined')
+        ? vueEnabled
+        : userOptions.typescript.vueComponents
     }
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1097,6 +1097,27 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@nodelib/fs.scandir@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
+  integrity sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.3"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
+  integrity sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
+  integrity sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.3"
+    fastq "^1.6.0"
+
 "@rollup/plugin-babel@^5.2.1":
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.2.1.tgz#20fc8f8864dc0eaa1c5578408459606808f72924"
@@ -1233,7 +1254,7 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/json-schema@*":
+"@types/json-schema@*", "@types/json-schema@^7.0.3":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
@@ -1281,6 +1302,76 @@
   integrity sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@typescript-eslint/eslint-plugin@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.5.0.tgz#4ff9c1d8535ae832e239f0ef6d7210592d9b0b07"
+  integrity sha512-mjb/gwNcmDKNt+6mb7Aj/TjKzIJjOPcoCJpjBQC9ZnTRnBt1p4q5dJSSmIqAtsZ/Pff5N+hJlbiPc5bl6QN4OQ==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "4.5.0"
+    "@typescript-eslint/scope-manager" "4.5.0"
+    debug "^4.1.1"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^3.0.0"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/experimental-utils@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.5.0.tgz#547fe1158609143ce60645383aa1d6f83ada28df"
+  integrity sha512-bW9IpSAKYvkqDGRZzayBXIgPsj2xmmVHLJ+flGSoN0fF98pGoKFhbunIol0VF2Crka7z984EEhFi623Rl7e6gg==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/scope-manager" "4.5.0"
+    "@typescript-eslint/types" "4.5.0"
+    "@typescript-eslint/typescript-estree" "4.5.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/parser@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.5.0.tgz#b2d659f25eec0041c7bc5660b91db1eefe8d7122"
+  integrity sha512-xb+gmyhQcnDWe+5+xxaQk5iCw6KqXd8VQxGiTeELTMoYeRjpocZYYRP1gFVM2C8Yl0SpUvLa1lhprwqZ00w3Iw==
+  dependencies:
+    "@typescript-eslint/scope-manager" "4.5.0"
+    "@typescript-eslint/types" "4.5.0"
+    "@typescript-eslint/typescript-estree" "4.5.0"
+    debug "^4.1.1"
+
+"@typescript-eslint/scope-manager@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.5.0.tgz#8dfd53c3256d4357e7d66c2fc8956835f4d239be"
+  integrity sha512-C0cEO0cTMPJ/w4RA/KVe4LFFkkSh9VHoFzKmyaaDWAnPYIEzVCtJ+Un8GZoJhcvq+mPFXEsXa01lcZDHDG6Www==
+  dependencies:
+    "@typescript-eslint/types" "4.5.0"
+    "@typescript-eslint/visitor-keys" "4.5.0"
+
+"@typescript-eslint/types@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.5.0.tgz#98256e07bad1c8d15d0c9627ebec82fd971bb3c3"
+  integrity sha512-n2uQoXnyWNk0Les9MtF0gCK3JiWd987JQi97dMSxBOzVoLZXCNtxFckVqt1h8xuI1ix01t+iMY4h4rFMj/303g==
+
+"@typescript-eslint/typescript-estree@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.5.0.tgz#d50cf91ae3a89878401111031eb6fb6d03554f64"
+  integrity sha512-gN1mffq3zwRAjlYWzb5DanarOPdajQwx5MEWkWCk0XvqC8JpafDTeioDoow2L4CA/RkYZu7xEsGZRhqrTsAG8w==
+  dependencies:
+    "@typescript-eslint/types" "4.5.0"
+    "@typescript-eslint/visitor-keys" "4.5.0"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/visitor-keys@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.5.0.tgz#b59f26213ac597efe87f6b13cf2aabee70542af0"
+  integrity sha512-UHq4FSa55NDZqscRU//O5ROFhHa9Hqn9KWTEvJGTArtTQp5GKv9Zqf6d/Q3YXXcFv4woyBml7fJQlQ+OuqRcHA==
+  dependencies:
+    "@typescript-eslint/types" "4.5.0"
+    eslint-visitor-keys "^2.0.0"
 
 abab@^2.0.3:
   version "2.0.5"
@@ -1407,6 +1498,11 @@ array-includes@^3.1.1:
     define-properties "^1.1.3"
     es-abstract "^1.17.0"
     is-string "^1.0.5"
+
+array-union@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
+  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -2155,6 +2251,13 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+dir-glob@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+  dependencies:
+    path-type "^4.0.0"
+
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -2424,7 +2527,7 @@ eslint-scope@^5.0.0, eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-utils@^2.1.0:
+eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
@@ -2671,6 +2774,18 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
+fast-glob@^3.1.1:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
+  integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+    picomatch "^2.2.1"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -2680,6 +2795,13 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fastq@^1.6.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.8.0.tgz#550e1f9f59bbc65fe185cb6a9b4d95357107f481"
+  integrity sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==
+  dependencies:
+    reusify "^1.0.4"
 
 fb-watchman@^2.0.0:
   version "2.0.1"
@@ -2838,7 +2960,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob-parent@^5.0.0:
+glob-parent@^5.0.0, glob-parent@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
@@ -2868,6 +2990,18 @@ globals@^12.1.0:
   integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
   dependencies:
     type-fest "^0.8.1"
+
+globby@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357"
+  integrity sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
 
 graceful-fs@^4.1.2, graceful-fs@^4.2.4:
   version "4.2.4"
@@ -3023,6 +3157,11 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.1.4:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
+  integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.2.1"
@@ -3980,6 +4119,11 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
+merge2@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
 micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -4458,6 +4602,11 @@ path-type@^2.0.0:
   dependencies:
     pify "^2.0.0"
 
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
 pbkdf2@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.1.tgz#cb8724b0fada984596856d1a6ebafd3584654b94"
@@ -4474,7 +4623,7 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.2:
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
@@ -4740,7 +4889,7 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexpp@^3.1.0:
+regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
@@ -4878,6 +5027,11 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+reusify@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 rimraf@2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
@@ -4911,6 +5065,11 @@ rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
+
+run-parallel@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
+  integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
@@ -5469,6 +5628,18 @@ tsconfig-paths@^3.9.0:
     json5 "^1.0.1"
     minimist "^1.2.0"
     strip-bom "^3.0.0"
+
+tslib@^1.8.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tsutils@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
- With Prettier support
- With Vue support, .vue files linting are automatically enabled if Vue support is enabled. It can be disabled.