### PR TITLE
fix(typescript): always allow .vue extension

### DIFF
--- a/src/config-generator.test.ts
+++ b/src/config-generator.test.ts
@@ -193,7 +193,7 @@ describe('Configuration generator', function () {
 
       const config = generateConfig(userOptions);
 
-      expect(config.parserOptions.extraFileExtensions).toBeUndefined();
+      expect(config.parserOptions.extraFileExtensions).toEqual(['.vue']);
       expect(config.overrides).toMatchObject([
         {
           files: ['*.js', '*.jsx', '*.vue'],

--- a/src/config-generator.ts
+++ b/src/config-generator.ts
@@ -120,12 +120,9 @@ function configureTypeScript(previousConfig: ESLintConfig, options: Options): ES
 
   if (options.vue) {
     config.parserOptions.parser = '@typescript-eslint/parser';
+    config.parserOptions.extraFileExtensions = ['.vue'];
   } else {
     config.parser = '@typescript-eslint/parser';
-  }
-
-  if (options.typescript.vueComponents) {
-    config.parserOptions.extraFileExtensions = ['.vue'];
   }
 
   config.rules = {


### PR DESCRIPTION
Apparently it's not related to Vue components